### PR TITLE
Add GitHub Action to Automatically Apply Labels to New Issues

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,16 @@
+name: Auto Label New Issues
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Label to New Issues
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "New"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,16 +1,17 @@
-name: Auto Label New Issues
-
+name: Auto Label new Issue
 on:
   issues:
     types:
       - opened
-
 jobs:
-  label:
+  label_issues:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-      - name: Add Label to New Issues
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "New"
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: New


### PR DESCRIPTION
This PR introduces a GitHub Action workflow that automatically applies a specified label to all newly created issues in the repository.

Changes Included:
- Added a workflow file `.github/workflows/auto-label.yml`.
- Configured the action to trigger when a new issue is opened.
- Automatically assigns the label `new`.